### PR TITLE
Make module name valid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module rfc9839
+module github.com/timbray/rfc9839
 
 go 1.22.0


### PR DESCRIPTION
The current module name is invalid, meaning that this package can't be used with standard Go tooling (ie. no `go get` to add it to your own project). This patch fixes the module name so that Go tools such as `go get` and `pkg.go.dev` can find the module.